### PR TITLE
Reformule le risque d'atteinte à la vie privée

### DIFF
--- a/docs/format-fichier.md
+++ b/docs/format-fichier.md
@@ -377,7 +377,7 @@ Il est possible que la combinaison des informations `EmploiGradeAgent`, `TempsCo
 
 `IndiceAgent` renseigne l'indice de l'agent de la collectivité. Il semblerait que cette information permette de retrouver le salaire de l'agent en question.
 
-Il n'est pas clair à ce jour si ces informations constituent une atteinte à la vie privée.
+Il n'est pas clair à ce jour si la publication de ces informations constitue une atteinte à la vie privée.
 
 
 #### Signature et signataires


### PR DESCRIPTION
Ce n'est pas à proprement parler les informations, mais leur divulgation, qui pourrait constituer une atteinte à la vie privée.